### PR TITLE
issue-02-corregir intervalo del scrapper de 100 minutos a 10 minutos

### DIFF
--- a/magic-services/services/scrapper/scryfall_scrapper.py
+++ b/magic-services/services/scrapper/scryfall_scrapper.py
@@ -12,6 +12,9 @@ from pathlib import Path
 
 from sentence_transformers import SentenceTransformer
 
+# Intervalo entre ejecuciones del modo loop (en minutos)
+INTERVALO_MINUTOS = 10
+
 # Cargar el modelo de embeddings una sola vez
 model = SentenceTransformer("sentence-transformers/all-mpnet-base-v2")
 
@@ -456,7 +459,7 @@ if __name__ == "__main__":
         else:
             print("\n✗ El scraping falló. Revisa el log para más detalles.")
     else:
-        print("Iniciando modo loop: ejecutando cada 10 minutos. Ctrl+C para detener.")
+        print(f"Iniciando modo loop: ejecutando cada {INTERVALO_MINUTOS} minutos. Ctrl+C para detener.")
         try:
             while True:
                 archivo = descargar_cartas_scryfall()
@@ -465,7 +468,7 @@ if __name__ == "__main__":
                 else:
                     print("\n✗ El scraping falló en esta iteración. Revisa el log.")
 
-                print("Esperando 10 minutos hasta la siguiente ejecución...\n")
-                time.sleep(100 * 60)
+                print(f"Esperando {INTERVALO_MINUTOS} minutos hasta la siguiente ejecución...\n")
+                time.sleep(INTERVALO_MINUTOS * 60)
         except KeyboardInterrupt:
             print("\nEjecución interrumpida por el usuario. Saliendo...")


### PR DESCRIPTION
El modo loop del scrapper ejecutaba cada 100 minutos en lugar de cada 10 minutos debido a un error en el valor literal pasado a time.sleep(). Los comentarios y mensajes del código indicaban correctamente "cada 10 minutos", pero la llamada usaba time.sleep(100 * 60) en vez de time.sleep(10 * 60).
Este PR corrige el problema extrayendo el valor del intervalo a una constante de módulo llamada INTERVALO_MINUTOS con valor 10, y actualizando tanto la llamada a time.sleep() como los mensajes de consola para que usen esa constante mediante f-strings. De esta forma se elimina la discrepancia entre el comportamiento real y el documentado, y se evita que futuros cambios en la frecuencia vuelvan a generar inconsistencias.
No se modifica la lógica de scraping; el único cambio es la duración de la pausa entre iteraciones del loop.