### PR TITLE
Issue 04-Refactorización: carga diferida del modelo de embeddings en el scrapper

### DIFF
--- a/magic-services/services/scrapper/scryfall_scrapper.py
+++ b/magic-services/services/scrapper/scryfall_scrapper.py
@@ -206,7 +206,7 @@ def descargar_cartas_scryfall(model: SentenceTransformer) -> Optional[str]:
     """
     Descarga todas las cartas de Magic: The Gathering desde la API de Scryfall
     y las guarda en un archivo JSON con solo los campos necesarios.
-    "
+    """
     
 
     # Definir rutas

--- a/magic-services/services/scrapper/scryfall_scrapper.py
+++ b/magic-services/services/scrapper/scryfall_scrapper.py
@@ -12,8 +12,12 @@ from pathlib import Path
 
 from sentence_transformers import SentenceTransformer
 
-# Cargar el modelo de embeddings una sola vez
-model = SentenceTransformer("sentence-transformers/all-mpnet-base-v2")
+
+def _cargar_modelo() -> SentenceTransformer:
+    """Carga el modelo de embeddings bajo demanda."""
+    print("Cargando modelo de embeddings...")
+    return SentenceTransformer("sentence-transformers/all-mpnet-base-v2")
+
 
 def _parse_mana_cost_to_cmc(mana_cost: Optional[str]) -> int:
     """
@@ -42,7 +46,7 @@ def _parse_mana_cost_to_cmc(mana_cost: Optional[str]) -> int:
 
     return total
 
-def filtrar_carta(carta: Dict[str, Any]) -> List[Dict[str, Any]]:
+def filtrar_carta(carta: Dict[str, Any], model: SentenceTransformer) -> List[Dict[str, Any]]:
     """
     Filtra los campos específicos de una carta según los requerimientos.
     Para cartas de doble cara, devuelve una lista con ambas caras.
@@ -198,11 +202,11 @@ def filtrar_carta(carta: Dict[str, Any]) -> List[Dict[str, Any]]:
 
     return cartas_resultado
 
-def descargar_cartas_scryfall() -> Optional[str]:
+def descargar_cartas_scryfall(model: SentenceTransformer) -> Optional[str]:
     """
     Descarga todas las cartas de Magic: The Gathering desde la API de Scryfall
     y las guarda en un archivo JSON con solo los campos necesarios.
-    """
+    "
     
 
     # Definir rutas
@@ -285,7 +289,7 @@ def descargar_cartas_scryfall() -> Optional[str]:
         
         cartas_filtradas = []
         for carta in cartas:
-            cartas_filtradas.extend(filtrar_carta(carta))  # extend porque puede devolver múltiples caras
+            cartas_filtradas.extend(filtrar_carta(carta, model))  # extend porque puede devolver múltiples caras
         
         logger.success(f"Filtrado completado: {len(cartas_filtradas)} registros procesados (incluyendo caras de cartas dobles)")
         #logger.set_cards_count(len(cartas_filtradas))
@@ -444,8 +448,10 @@ if __name__ == "__main__":
     # - 'loop' -> ejecutar periódicamente cada 10 minutos (comportamiento por defecto)
     mode = os.getenv("SCRAPPER_MODE", "loop").lower()
 
+    model = _cargar_modelo()
+
     if mode == "once":
-        archivo = descargar_cartas_scryfall()
+        archivo = descargar_cartas_scryfall(model)
 
         if archivo:
             print(f"\n✓ Los datos están disponibles en: {archivo}")
@@ -459,7 +465,7 @@ if __name__ == "__main__":
         print("Iniciando modo loop: ejecutando cada 10 minutos. Ctrl+C para detener.")
         try:
             while True:
-                archivo = descargar_cartas_scryfall()
+                archivo = descargar_cartas_scryfall(model)
                 if archivo:
                     print(f"\n✓ Los datos están disponibles en: {archivo}")
                 else:


### PR DESCRIPTION
El modelo de embeddings (all-mpnet-base-v2, ~400 MB) se cargaba como variable global a nivel de módulo, lo que significaba que se descargaba y se cargaba en memoria en cuanto se importaba el archivo, independientemente de si se iba a usar o no. Esto ralentizaba el arranque del contenedor y hacía imposible importar el módulo para usar funciones auxiliares sin pagar el coste de cargar el modelo completo.
Este PR elimina la variable global y encapsula la carga en una función dedicada _cargar_modelo(). El modelo se instancia una sola vez en el bloque __main__, justo antes de necesitarlo, y se pasa como parámetro a las funciones que lo requieren (descargar_cartas_scryfall y filtrar_carta). De esta forma se sigue el principio de inyección de dependencias: el flujo de datos es explícito, se facilita el testing mediante mocks y se centraliza la configuración del modelo en un único punto.
No hay cambios funcionales. El comportamiento del script al ejecutarse directamente sigue siendo idéntico, pero el módulo ya se puede importar sin efectos secundarios costosos y el contenedor arranca más rápido.