### PR TITLE
Issue 09- Fix: fijar versiones exactas de dependencias en requirements.txt

### DIFF
--- a/magic-services/services/api/requirements.txt
+++ b/magic-services/services/api/requirements.txt
@@ -1,2 +1,2 @@
-fastapi>=0.95.0
-uvicorn[standard]>=0.22.0
+fastapi==0.111.0
+uvicorn[standard]==0.30.1

--- a/magic-services/services/scrapper/requirements.txt
+++ b/magic-services/services/scrapper/requirements.txt
@@ -1,12 +1,12 @@
-requests>=2.31.0
-
+requests==2.32.3
+ 
 # Librería principal
 sentence-transformers==3.0.1
-
+ 
 # Dependencias críticas
 torch==2.2.1
 transformers==4.40.2
-
+ 
 # Utilidades adicionales que suelen ser necesarias
 numpy==1.26.4
 scikit-learn==1.5.0


### PR DESCRIPTION
Los archivos requirements.txt del chatbot, la API y el scrapper usaban dependencias sin versión fija o con rangos mínimos (por ejemplo pymupdf, fastapi>=0.95.0, requests>=2.31.0), lo que provocaba que cada build del contenedor pudiera instalar versiones distintas e introducir incompatibilidades o comportamientos inesperados.
Este commit fija todas las dependencias a versiones exactas con el operador == en los tres archivos afectados: el chatbot (pymupdf==1.24.5, fastapi==0.111.0, etc.), la API (fastapi==0.111.0, uvicorn==0.30.1) y el scrapper (requests==2.32.3). Con esto se garantizan builds reproducibles y se elimina el riesgo de roturas por actualizaciones implícitas de paquetes.